### PR TITLE
WIP: Add ordering method

### DIFF
--- a/scalagen/src/main/scala/org/scalameta/scalagen/Runner.scala
+++ b/scalagen/src/main/scala/org/scalameta/scalagen/Runner.scala
@@ -15,6 +15,11 @@ import scala.meta.gen.{
 
 case class TransmutationResult(in: Stat, out: List[Defn])
 
+object Runner {
+  val statOrdering: (Stat, Stat) => Boolean = (x: Stat, y: Stat) =>
+    x.isInstanceOf[Defn.Object] && !y.isInstanceOf[Defn.Object]
+}
+
 /**
   * Will transform only extension generators.
   * But is the fastest and easiest to implement

--- a/scalagen/src/test/scala/org/scalameta/scalagen/TestTraversalOrder.scala
+++ b/scalagen/src/test/scala/org/scalameta/scalagen/TestTraversalOrder.scala
@@ -1,0 +1,37 @@
+package org.scalameta.scalagen
+
+import org.scalatest.FunSuite
+import scala.meta._
+import scala.meta.contrib._
+import scala.meta.gen._
+
+class TestTraversalOrder extends FunSuite {
+
+  test("Companions are reordered") {
+    val in =
+      source"""
+         class Foo
+         object Foo
+         object Bar
+         class Bar
+         trait Bar
+         object Bax
+      """
+
+    val expected =
+      source"""
+         object Foo
+         object Bar
+         object Bax
+         class Foo
+         class Bar
+         trait Bar
+      """
+
+    val res = in.withStats(in.extract[Stat].sortWith(Runner.statOrdering))
+
+    withClue(res.syntax) {
+      assert(res isEqual expected)
+    }
+  }
+}


### PR DESCRIPTION
Not actually hooked up to the Runner yet.

We need to decide whether we should sort the entire tree, or only on demand (eg, when there is going to be an companion extension generator conflict)

Will eventually fix #25 