### PR TITLE
Make generators objects

### DIFF
--- a/scalagen/src/test/scala/org/scalameta/scalagen/Examples.scala
+++ b/scalagen/src/test/scala/org/scalameta/scalagen/Examples.scala
@@ -10,7 +10,7 @@ import scala.meta.gen._
   * Will print the structure of the class as it's toString.
   * Not super useful, but a simple example to test with
   */
-case class SyntaxToString() extends ExtensionGenerator("SyntaxToString") {
+object SyntaxToString extends ExtensionGenerator("SyntaxToString") {
   override def extend(d: Defn.Class): List[Stat] = {
     val syntax: Lit.String = Lit.String(d.withStats(Nil).syntax)
     val newToString: Defn.Def = q"def toString = $syntax"
@@ -19,7 +19,7 @@ case class SyntaxToString() extends ExtensionGenerator("SyntaxToString") {
   }
 }
 
-case class PrintHi() extends ExtensionGenerator("PrintHi") {
+object PrintHi extends ExtensionGenerator("PrintHi") {
   override def extend(c: Defn.Class): List[Stat] = {
     val hi: Lit.String = Lit.String("hi")
     val hiMethod: Defn.Def =
@@ -29,7 +29,7 @@ case class PrintHi() extends ExtensionGenerator("PrintHi") {
   }
 }
 
-case class PrintHiInCompanion() extends CompanionGenerator("PrintHiInCompanion") {
+object PrintHiInCompanion extends CompanionGenerator("PrintHiInCompanion") {
   override def extendCompanion(c: Defn.Class): List[Stat] = {
     val hi: Lit.String = Lit.String("hi")
     val hiMethod: Defn.Def =
@@ -39,7 +39,7 @@ case class PrintHiInCompanion() extends CompanionGenerator("PrintHiInCompanion")
   }
 }
 
-case class TestRecurse() extends ExtensionGenerator("TestRecurse") {
+object TestRecurse extends ExtensionGenerator("TestRecurse") {
   override def extend(c: Defn.Class): List[Stat] = {
     val clazz = q"@PrintHi class Foo"
 
@@ -47,7 +47,7 @@ case class TestRecurse() extends ExtensionGenerator("TestRecurse") {
   }
 }
 
-case class LogCalls() extends ManipulationGenerator("LogCalls") {
+object LogCalls extends ManipulationGenerator("LogCalls") {
   override def manipulate(d: Defn.Def): Defn.Def = {
     val stats = d.extract[Stat]
     val logger = q"println(${d.name.value + " was called"})"
@@ -55,7 +55,7 @@ case class LogCalls() extends ManipulationGenerator("LogCalls") {
   }
 }
 
-case class Freeish() extends TransmutationGenerator("Freeish") {
+object Freeish extends TransmutationGenerator("Freeish") {
   override def transmute(t: Defn.Trait): List[Defn] = {
     val names: List[Term.Name] = t.extract[Stat].collect {
       case d: Defn.Def => d.name
@@ -73,7 +73,7 @@ case class Freeish() extends TransmutationGenerator("Freeish") {
   }
 }
 
-case class DeleteMe() extends TransmutationGenerator("DeleteMe") {
+object DeleteMe extends TransmutationGenerator("DeleteMe") {
   override def transmute(t: Defn.Trait): List[Defn] = Nil
   override def transmute(c: Defn.Class): List[Stat] = Nil
   override def transmute(t: Defn.Type): List[Stat] = Nil
@@ -87,12 +87,12 @@ case class DeleteMe() extends TransmutationGenerator("DeleteMe") {
   override def transmute(t: Decl.Type): List[Stat] = Nil
 }
 
-case class Abort() extends ExtensionGenerator("Abort") {
+object Abort extends ExtensionGenerator("Abort") {
   override def extend(c: Defn.Class): List[Stat] =
     abort("Nothing to see here...")
 }
 
-case class NonNull() extends ParameterGenerator("NonNull") {
+object NonNull extends ParameterGenerator("NonNull") {
   override def extend(p: Term.Param): List[Stat] = {
     val value = q"assert(${p.name.asTerm} != null)"
     value :: Nil

--- a/scalagen/src/test/scala/org/scalameta/scalagen/TestCompanionExtension.scala
+++ b/scalagen/src/test/scala/org/scalameta/scalagen/TestCompanionExtension.scala
@@ -16,7 +16,7 @@ class TestCompanionExtension extends GeneratorSuite {
                }
              """
 
-    val res = generate(src, PrintHiInCompanion())
+    val res = generate(src, PrintHiInCompanion)
 
     withClue(res.syntax) {
       assert(expected isEqual res)
@@ -42,7 +42,7 @@ class TestCompanionExtension extends GeneratorSuite {
                }
              """
 
-    val res = generate(src, PrintHiInCompanion())
+    val res = generate(src, PrintHiInCompanion)
 
     withClue(res.syntax) {
       assert(expected isEqual res)

--- a/scalagen/src/test/scala/org/scalameta/scalagen/TestErrorHandler.scala
+++ b/scalagen/src/test/scala/org/scalameta/scalagen/TestErrorHandler.scala
@@ -10,7 +10,7 @@ class TestErrorHandler extends GeneratorSuite {
       q"@Abort case class Foo(x: Int, y: Int)"
 
     assertThrows[FatalGenerationException] {
-      generate(clazz, Abort())
+      generate(clazz, Abort)
     }
   }
 

--- a/scalagen/src/test/scala/org/scalameta/scalagen/TestExtensions.scala
+++ b/scalagen/src/test/scala/org/scalameta/scalagen/TestExtensions.scala
@@ -15,7 +15,7 @@ class TestExtensions extends GeneratorSuite {
           }
        """
 
-    val res = generate(clazz, SyntaxToString())
+    val res = generate(clazz, SyntaxToString)
 
     withClue(res.syntax) {
       assert(expected isEqual res)
@@ -33,7 +33,7 @@ class TestExtensions extends GeneratorSuite {
         }
        """
 
-    val res = generate(clazz, SyntaxToString(), PrintHi())
+    val res = generate(clazz, SyntaxToString, PrintHi)
 
     withClue(res.syntax) {
       assert(expected isEqual res)
@@ -51,7 +51,7 @@ class TestExtensions extends GeneratorSuite {
         }
        """
 
-    val res = generate(clazz, PrintHi())
+    val res = generate(clazz, PrintHi)
 
     withClue(res.syntax) {
       assert(expected isEqual res)
@@ -68,7 +68,7 @@ class TestExtensions extends GeneratorSuite {
         }
        """
 
-    val res = generate(clazz, PrintHi(), TestRecurse())
+    val res = generate(clazz, PrintHi, TestRecurse)
 
     withClue(res.syntax) {
       assert(expected isEqual res)
@@ -87,7 +87,7 @@ class TestExtensions extends GeneratorSuite {
         }
        """
 
-    val res = generateRecursive(clazz, PrintHi(), TestRecurse())
+    val res = generateRecursive(clazz, PrintHi, TestRecurse)
 
     withClue(res.syntax) {
       assert(expected isEqual res)
@@ -110,7 +110,7 @@ class TestExtensions extends GeneratorSuite {
         }
        """
 
-    val res = generate(clazz, PrintHi(), TestRecurse())
+    val res = generate(clazz, PrintHi, TestRecurse)
 
     withClue(res.syntax) {
       assert(expected isEqual res)
@@ -119,7 +119,7 @@ class TestExtensions extends GeneratorSuite {
 
   test("Expansion noop") {
     val clazz: Defn.Class = q"case class Foo(x: Int, y: Int)"
-    val res = generate(clazz, PrintHi(), TestRecurse())
+    val res = generate(clazz, PrintHi, TestRecurse)
 
     withClue(res.syntax) {
       assert(clazz isEqual res)

--- a/scalagen/src/test/scala/org/scalameta/scalagen/TestManipulation.scala
+++ b/scalagen/src/test/scala/org/scalameta/scalagen/TestManipulation.scala
@@ -15,7 +15,7 @@ class TestManipulation extends GeneratorSuite {
         }
        """
 
-    val res = generate(deff, LogCalls())
+    val res = generate(deff, LogCalls)
 
     withClue(res.syntax) {
       assert(expected isEqual res)

--- a/scalagen/src/test/scala/org/scalameta/scalagen/TestParameterGenerators.scala
+++ b/scalagen/src/test/scala/org/scalameta/scalagen/TestParameterGenerators.scala
@@ -15,7 +15,7 @@ class TestParameterGenerators extends GeneratorSuite {
           }
        """
 
-    val res = generate(clazz, NonNull())
+    val res = generate(clazz, NonNull)
 
     withClue(res.syntax) {
       assert(expected isEqual res)

--- a/scalagen/src/test/scala/org/scalameta/scalagen/TestTransmutation.scala
+++ b/scalagen/src/test/scala/org/scalameta/scalagen/TestTransmutation.scala
@@ -19,7 +19,7 @@ class TestTransmutation extends GeneratorSuite {
                case class ask() extends IO
              """
 
-    val res = generate(src, Freeish())
+    val res = generate(src, Freeish)
 
     withClue(res.syntax) {
       assert(expected isEqual res)
@@ -36,7 +36,7 @@ class TestTransmutation extends GeneratorSuite {
 
     val expected: Source = source""
 
-    val res = generate(src, DeleteMe())
+    val res = generate(src, DeleteMe)
 
     withClue(res.syntax) {
       assert(expected isEqual res)
@@ -52,7 +52,7 @@ class TestTransmutation extends GeneratorSuite {
 
     val expected: Source = source"trait Foo {}"
 
-    val res = generate(src, DeleteMe())
+    val res = generate(src, DeleteMe)
 
     withClue(res.syntax) {
       assert(expected isEqual res)


### PR DESCRIPTION
For parameterless Generators, simplify the process by making them singletons.
